### PR TITLE
fix(dapps): display Dapps in a two-column grid

### DIFF
--- a/src/components/skeleton/dappsSkeleton.tsx
+++ b/src/components/skeleton/dappsSkeleton.tsx
@@ -8,7 +8,7 @@ interface IProps {
 
 const DappsSkeleton = ({ size }: IProps) => {
     return (
-        <View style={[styles.contentWrap, { width: size }]}>
+        <View style={styles.contentWrap}>
             <View style={{ paddingHorizontal: 10, height: size - 20 }}>
                 <ContentLoader speed={0.8} animate={true} foregroundColor={DividerColor} backgroundColor={BoxColor}>
                     <Rect x="0" y="0" rx="8" ry="8" width={'100%'} height={size - 20} />
@@ -21,6 +21,8 @@ const DappsSkeleton = ({ size }: IProps) => {
 
 const styles = StyleSheet.create({
     contentWrap: {
+        width: '50%',
+        flexShrink: 0,
         marginBottom: 52
     }
 });

--- a/src/organisms/dapps/index.tsx
+++ b/src/organisms/dapps/index.tsx
@@ -70,7 +70,7 @@ const Dapps = () => {
     const DappItem = useCallback(
         ({ item, size }: any) => {
             return (
-                <TouchableOpacity style={[styles.contentWrap, { width: size }]} onPress={() => moveToDetail(item)}>
+                <TouchableOpacity style={styles.contentWrap} onPress={() => moveToDetail(item)}>
                     <Animated.View style={{ paddingHorizontal: 10 }}>
                         <View style={[styles.contentImage, { width: '100%', height: size - 20, backgroundColor: BoxColor }]}>
                             <Animated.Image
@@ -162,6 +162,8 @@ const styles = StyleSheet.create({
         paddingHorizontal: 10
     },
     contentWrap: {
+        width: '50%',
+        flexShrink: 0,
         marginBottom: 20
     },
     contentImage: {


### PR DESCRIPTION
 Summary
 - Updated Dapps items to use a two-column layout.
 - Prevented flex shrinking on Dapp items.
 - Applied the same layout to loading skeletons.
 - Aligned loaded and loading states consistently.
